### PR TITLE
feat: Add host-context pseudo class

### DIFF
--- a/switch-web-component.js
+++ b/switch-web-component.js
@@ -380,10 +380,21 @@
     }
 
     /*
+    https://developer.mozilla.org/en-US/docs/Web/CSS/:host-context()
+    */
+    :host-context([dir="rtl"]) .switch .switch__lever {
+      --dirLTR: -1;
+    }
+
+    /*
       For Browsers That Support dir() pseudo-class. As of 04.2021 only Firefox 49 has full support.
       https://developer.mozilla.org/en-US/docs/Web/CSS/:dir
     */
     .switch:dir(rtl) .switch__lever {
+      --dirLTR: -1;
+    }
+
+    :host-context(:dir(rtl)) .switch .switch__lever {
       --dirLTR: -1;
     }
 
@@ -435,11 +446,19 @@
       --transform-origin: 100% 50%;
     }
 
+    :host-context([dir="rtl"]) .switch--elastic .switch__lever {
+      --transform-origin: 100% 50%;
+    }
+
     /*
       For Browsers That Support dir() pseudo-class. As of 04.2021 only Firefox 49 has full support.
       https://developer.mozilla.org/en-US/docs/Web/CSS/:dir
     */
     .switch:dir(rtl) .switch--elastic .switch__lever {
+      --transform-origin: 100% 50%;
+    }
+
+    :host-context(:dir(rtl)) .switch--elastic .switch__lever {
       --transform-origin: 100% 50%;
     }
 
@@ -452,12 +471,20 @@
       --transform-origin: 0% 50%;
     }
 
+    :host-context([dir="rtl"]) .switch--elastic [type="checkbox"]:checked ~ .switch__lever {
+      --transform-origin: 0% 50%;
+    }
+
     /*
       For Browsers That Support dir() pseudo-class. As of 04.2021 only Firefox 49 has full support.
       https://developer.mozilla.org/en-US/docs/Web/CSS/:dir
     */
     .switch:dir(rtl) .switch--elastic [type="checkbox"]:checked ~ .switch__lever {
      --transform-origin: 0% 50%;
+    }
+
+    :host-context(:dir(rtl)) .switch--elastic [type="checkbox"]:checked ~ .switch__lever {
+      --transform-origin: 0% 50%;
     }
 
     .switch--elastic:active .switch__lever::before,


### PR DESCRIPTION
- This pseudo class helps target ancestors of the web component.
- It was used to account for the RTL direction (dir="rtl") attribute on the ancestors